### PR TITLE
Launcher Window Resize Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "falcon": "file:",
         "lucide-react": "^0.507.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1911,6 +1912,10 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/falcon": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "falcon": "file:",
     "lucide-react": "^0.507.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
@@ -21,10 +22,10 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "~5.6.2",
-    "vite": "^6.0.3",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.0",
+    "typescript": "~5.6.2",
+    "vite": "^6.0.3"
   }
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,11 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "core:window:allow-set-size",
+    "core:window:allow-set-resizable",
+    "core:window:allow-center",
+    "core:window:allow-set-maximizable",
+    "core:window:allow-set-focus"
   ]
 }

--- a/src/FalconClient.jsx
+++ b/src/FalconClient.jsx
@@ -2,6 +2,7 @@ import {useEffect, useState} from 'react';
 import {Settings, Package, Home, Newspaper, Play, X, Minus, ChevronRight} from 'lucide-react';
 import {invoke} from "@tauri-apps/api/core";
 import {listen} from '@tauri-apps/api/event';
+import { LogicalSize, getCurrentWindow, currentMonitor } from '@tauri-apps/api/window';
 
 
 export default function FalconClient() {
@@ -12,6 +13,35 @@ export default function FalconClient() {
     const [selectedVersion, setSelectedVersion] = useState("");
     const [username, setUsername] = useState("");
     const [statusMessage, setStatusMessage] = useState('Ready to play');
+
+        useEffect(() => {
+        async function lockWindow() {
+            const monitor = await currentMonitor();
+
+            // Something must be seriously wrong with the person using the app.
+            if (!monitor) {
+                console.log("What the actual fuck happened here?!");
+            }
+
+            // Calculate what size the window needs to be in order to keep the elements clean and 
+            // user-friendly according to the (poor ahh) user's aspect ratio
+            const independantMultiplier = 1.2;
+            const aspectRatio = monitor.size.width / monitor.size.height;
+            const width = (monitor.size.width / aspectRatio) * independantMultiplier;
+            const height = (monitor.size.height / aspectRatio) * independantMultiplier;
+
+            const cwin = await getCurrentWindow();
+            await cwin.setSize(new LogicalSize(width, height));
+            await cwin.center();
+            await cwin.setResizable(false);
+            await cwin.setMaximizable(false);
+            await cwin.setFocus();
+        }
+
+        // For some reason tauri wants everything to be async, needy ass fucker
+        lockWindow().catch(console.error);
+    }, []);
+
     useEffect(() => {
         invoke("get_versions")
             .then((v) => setVersions(v))


### PR DESCRIPTION
Made the window resize and center itself according to the user's monitor aspect ratio, keeping it at a good and user-friendly size.

Also turned off resizing and maximizing since a Minecraft Launcher doesn't need them, therefore eliminating the need for making the react code "responsive".